### PR TITLE
allow null as value in source

### DIFF
--- a/tasks/shared-config.js
+++ b/tasks/shared-config.js
@@ -81,7 +81,7 @@ module.exports = function( grunt ) {
 		}
 
 		function getStyleSafeValue( value ) {
-			if ( !isStringNumber( value ) && value[ 0 ] !== "#"	&& typeof value !== "boolean" ) {
+			if ( value !== null && !isStringNumber( value ) && value[ 0 ] !== "#" && typeof value !== "boolean" ) {
 				value = "\"" + value + "\"";
 			}
 			return value;

--- a/test/expected/config-amd.js
+++ b/test/expected/config-amd.js
@@ -17,6 +17,7 @@ define( function() {
 		"STRING": "a/path/to/something.png",
 		"TRUEFALSE": true,
 		"TRUEFALSESTRING": "true",
+		"N": null,
 		"OFFSET": 20
 	}
 

--- a/test/expected/config.js
+++ b/test/expected/config.js
@@ -15,5 +15,6 @@ var globalConfig = {
 	"string": "a/path/to/something.png",
 	"truefalse": true,
 	"truefalsestring": "true",
+	"n": null,
 	"offset": 20
 };

--- a/test/expected/config.less
+++ b/test/expected/config.less
@@ -10,4 +10,5 @@
 @string: "a/path/to/something.png";
 @truefalse: true;
 @truefalsestring: "true";
+@n: null;
 @offset: 20px;

--- a/test/expected/config.sass
+++ b/test/expected/config.sass
@@ -10,4 +10,5 @@ $car-inner-seat: 10px
 $string: "a/path/to/something.png"
 $truefalse: true
 $truefalsestring: "true"
+$n: null
 $offset: 20px

--- a/test/expected/config.scss
+++ b/test/expected/config.scss
@@ -10,4 +10,5 @@ $car-inner-seat: 10px;
 $string: "a/path/to/something.png";
 $truefalse: true;
 $truefalsestring: "true";
+$n: null;
 $offset: 20px;

--- a/test/expected/config.styl
+++ b/test/expected/config.styl
@@ -10,4 +10,5 @@ car-inner-seat = 10px
 string = "a/path/to/something.png"
 truefalse = true
 truefalsestring = "true"
+n = null
 offset = 20px

--- a/test/expected/config1.js
+++ b/test/expected/config1.js
@@ -15,5 +15,6 @@ var globalConfig = {
 	"string": "a/path/to/something.png",
 	"truefalse": true,
 	"truefalsestring": "true",
+	"n": null,
 	"offset": 20
 };

--- a/test/expected/configMaps.scss
+++ b/test/expected/configMaps.scss
@@ -14,5 +14,6 @@ $globalConfig: (
 	),
 	string: "a/path/to/something.png",
 	truefalse: true,
-	truefalsestring: "true"
+	truefalsestring: "true",
+	n: null
 );

--- a/test/expected/config_mask3.scss
+++ b/test/expected/config_mask3.scss
@@ -10,5 +10,6 @@ $globalConfig: (
 	),
 	string: "a/path/to/something.png",
 	truefalse: true,
-	truefalsestring: "true"
+	truefalsestring: "true",
+	n: null
 );

--- a/test/expected/config_mask4.scss
+++ b/test/expected/config_mask4.scss
@@ -13,5 +13,6 @@ $globalConfig: (
 	),
 	string: "a/path/to/something.png",
 	truefalse: true,
-	truefalsestring: "true"
+	truefalsestring: "true",
+	n: null
 );

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -14,5 +14,6 @@
 	},
 	"string": "a/path/to/something.png",
 	"truefalse" : true,
-	"truefalsestring" : "true"
+	"truefalsestring" : "true",
+	"n": null
 }

--- a/test/fixtures/config.yml
+++ b/test/fixtures/config.yml
@@ -12,3 +12,4 @@ car:
 string: a/path/to/something.png
 truefalse: true
 truefalsestring: "true"
+n: null

--- a/test/shared_config_test.js
+++ b/test/shared_config_test.js
@@ -70,7 +70,7 @@ exports.shared_config = {
 		var actual = grunt.file.read( "tmp/config-amd.js" );
 		var expected = grunt.file.read( "test/expected/config-amd.js" );
 
-		test.equal( actual, expected, "JS AMD should be equal." );
+		test.equal( actual, expected, "JS AMD (config-amd.js) should be equal." );
 
 		test.done();
 	},
@@ -83,8 +83,8 @@ exports.shared_config = {
 			sassMaps1: [ grunt.file.read( "tmp/configMaps1.scss"), grunt.file.read( "test/expected/configMaps1.scss" ) ]
 		};
 
-		test.equal( files.sassMaps[ 0 ], files.sassMaps[ 1 ], "SASS Maps  (configMaps.scss) should be equal." );
-		test.equal( files.sassMaps1[ 0 ], files.sassMaps1[ 1 ], "SASS Maps  (configMaps1.scss) should be equal." );
+		test.equal( files.sassMaps[ 0 ], files.sassMaps[ 1 ], "SASS Maps (configMaps.scss) should be equal." );
+		test.equal( files.sassMaps1[ 0 ], files.sassMaps1[ 1 ], "SASS Maps (configMaps1.scss) should be equal." );
 
 		test.done();
 	},


### PR DESCRIPTION
This fixes `getStyleSafeValue` to not fail, when value is `null`.
