### PR TITLE
introduce basic support for CSS expressions

### DIFF
--- a/tasks/shared-config.js
+++ b/tasks/shared-config.js
@@ -80,8 +80,16 @@ module.exports = function( grunt ) {
 			}, false );
 		}
 
+		function isCSSExpression( value ) {
+			var exprs = [ /^[A-Za-z_\-]+\(.*\)$/ ];
+
+			return exprs.reduce( function( previous, current ) {
+				return previous || ( new RegExp(current) ).test( value );
+			}, false );
+		}
+
 		function getStyleSafeValue( value ) {
-			if ( value !== null && !isStringNumber( value ) && value[ 0 ] !== "#" && typeof value !== "boolean" ) {
+			if ( value !== null && !isStringNumber( value ) && !isCSSExpression( value ) && value[ 0 ] !== "#" && typeof value !== "boolean" ) {
 				value = "\"" + value + "\"";
 			}
 			return value;


### PR DESCRIPTION
This commit introduces basic support for CSS expressions such as:
- rgba()
- rgb()
- url()
- translate()
- rotate()
- etc.

For instance the following configuration file:

```
{
    color: "rgba(100, 100, 100, 0.2)"
}
```

Will be exported as follow in CSS:

```
$color: rgba(100, 100, 100, 0.2);
```

and will be exported as follow in JavaScript:

```
var options = {
    "color": "rgba(100, 100, 100, 0.2)"
}
```
