### PR TITLE
newModule option for angular constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,21 +50,38 @@ Same as `options.cssFormat` but for js files.
 Type: `Boolean`
 Default value: `false`
 
-Defines weather or not JS files are written in AMD style or as plain objects.
+Defines whether or not JS files are written in AMD style or as plain objects.
 
 
 #### options.ngconstant
 Type: `Boolean`
 Default value: `false`
 
-Defines weather or not JS files are written in Angular constant module style or as plain objects. *Note*: Can not be used with AMD.
+Defines whether or not JS files are written in Angular constant module style or as plain objects. *Note*: Can not be used with AMD.
 
 
 #### options.module
 Type: `String`
 Default value: `"globalConfig.sharedConfig"`
 
-This string determines the name of the Angulare constent module.
+This string determines the name of the Angulare constant module.
+
+
+#### options.newModule
+Type: `Boolean`
+Default value: `true`
+
+Defines whether or not created angular module should be new.
+
+true:
+```js
+	angular.module("globalConfig.sharedConfig", [])
+```
+
+false: 
+```js
+	angular.module("globalConfig.sharedConfig")
+```
 
 
 #### options.name

--- a/tasks/shared-config.js
+++ b/tasks/shared-config.js
@@ -155,6 +155,7 @@ module.exports = function( grunt ) {
 			singlequote: false,
 			name: "config",
 			module: "globalConfig.sharedConfig",
+			newModule: true,
 			useSassMaps: false,
 			indention: "\t",
 			mask: undefined,
@@ -179,7 +180,7 @@ module.exports = function( grunt ) {
 			sassmaps:   "{{key}}: {{value}},",
 			styl:       "{{key}} = {{value}}\n",
 			amd:        "define( function() {\n\n" + options.indention + "return {{{vars}}" + options.indention + "}\n\n} );\n",
-			ngconstant: "angular.module(\"{{module}}\", [])\n" + options.indention + ".constant(\"{{name}}\", {{{vars}}" + options.indention + "});",
+			ngconstant: "angular.module(\"{{module}}\"" + (options.newModule ? ', []' : '') + ")\n" + options.indention + ".constant(\"{{name}}\", {{{vars}}" + options.indention + "});",
 			js:         "var {{name}} = {{vars}};\n"
 		};
 


### PR DESCRIPTION
Very useful if you want to connect config to an existing module

#### options.newModule
Type: `Boolean`
Default value: `true`

Defines whether or not created angular module should be new.

true:
```js
	angular.module("globalConfig.sharedConfig", [])
```

false: 
```js
	angular.module("globalConfig.sharedConfig")
```