### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,11 @@
 	"description": "Create config files for SASS/SCSS/LESS/Stylus and JS from one source",
 	"version": "0.3.16",
 	"homepage": "https://github.com/MathiasPaumgarten/grunt-shared-config",
-
 	"author": {
 		"name": "Mathias Paumgarten",
 		"email": "mail@mathias-paumgarten.com",
 		"url": "http://mathias-paumgarten.com"
 	},
-
 	"contributors": [
 		{
 			"name": "Tobias Klika",
@@ -24,33 +22,26 @@
 			"email": "dev@remibarraquand.com"
 		}
 	],
-
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/MathiasPaumgarten/grunt-shared-config"
 	},
-
 	"bugs": {
 		"url": "https://github.com/MathiasPaumgarten/grunt-shared-config/issues"
 	},
-
 	"licenses": [
 		{
 			"type": "MIT",
 			"url": "/blob/master/LICENSE-MIT"
 		}
 	],
-
 	"main": "Gruntfile.js",
-
 	"engines": {
 		"node": ">= 0.8.0"
 	},
-
 	"scripts": {
 		"test": "grunt test"
 	},
-
 	"devDependencies": {
 		"grunt-contrib-jshint": "~0.11.2",
 		"grunt-contrib-clean": "~0.6.0",
@@ -59,15 +50,12 @@
 		"grunt-cli": "~0.1.8",
 		"grunt": "~0.4.5"
 	},
-
 	"peerDependencies": {
-		"grunt": "~0.4.0"
+		"grunt": ">=0.4.0"
 	},
-
 	"dependencies": {
 		"mout": "~0.9.0"
 	},
-
 	"keywords": [
 		"gruntplugin",
 		"sass",


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
